### PR TITLE
Remove `SetBaseURL()`

### DIFF
--- a/hit.go
+++ b/hit.go
@@ -39,7 +39,6 @@ package hit
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"golang.org/x/xerrors"
@@ -67,9 +66,6 @@ type Hit interface {
 
 	// BaseURL returns the current base url.
 	BaseURL() string
-
-	// SetBaseURL sets the base url.
-	SetBaseURL(url string, a ...interface{})
 
 	// CurrentStep returns the current working step.
 	CurrentStep() IStep
@@ -165,10 +161,6 @@ func (hit *hitImpl) SetHTTPClient(client *http.Client) error {
 
 func (hit *hitImpl) BaseURL() string {
 	return hit.baseURL
-}
-
-func (hit *hitImpl) SetBaseURL(url string, a ...interface{}) {
-	hit.baseURL = fmt.Sprintf(url, a...)
 }
 
 func (hit *hitImpl) collectSteps(state StepTime) []IStep {

--- a/static.go
+++ b/static.go
@@ -2,6 +2,7 @@ package hit
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -154,7 +155,10 @@ func BaseURL(url string, a ...interface{}) IStep {
 		When:     requestCreateStep,
 		CallPath: newCallPath("BaseURL", nil),
 		Exec: func(hit *hitImpl) error {
-			hit.SetBaseURL(url, a...)
+			if len(a) > 0 {
+				url = fmt.Sprintf(url, a...)
+			}
+			hit.baseURL = url
 			return nil
 		},
 	}
@@ -192,7 +196,7 @@ func makeMethodStep(fnName, method, url string, a ...interface{}) IStep {
 		CallPath: newCallPath(fnName, nil),
 		Exec: func(hit *hitImpl) error {
 			hit.request.Method = method
-			url = misc.MakeURL(hit.BaseURL(), url, a...)
+			url = misc.MakeURL(hit.baseURL, url, a...)
 			if url == "" {
 				hit.request.URL = new(urlpkg.URL)
 				return nil


### PR DESCRIPTION
## Description

## Problem
`SetBaseURL()` was defunct because of the recent `Request()` changes.

## Solution
Remove `SetBaseURL()` because we can always use `hit.Do(BaseURL())`.

## Notes
Other notes that you want to share but do not fit into _Problem_ or _Solution_.

### Checklist
- [x] Ran `make test`
- [x] Review `README.md` `go //ignore` sections
- [x] Added Changelog entry to `README.md` when this is a `#major` or `#minor` release. 

<!--
Bumping
Any commit message that includes #major, #minor, or #patch will trigger the respective version bump.
If two or more are present, the highest-ranking one will take precedence.
If no #major, #minor or #patch tag is contained in the commit messages, it will bump patch.
-->