### PR TITLE
Ignore `nil` steps

### DIFF
--- a/hit.go
+++ b/hit.go
@@ -166,6 +166,9 @@ func (hit *hitImpl) BaseURL() string {
 func (hit *hitImpl) collectSteps(state StepTime) []IStep {
 	var collectedSteps []IStep
 	for i := 0; i < len(hit.steps); i++ {
+		if hit.steps[i] == nil {
+			continue
+		}
 		w := hit.steps[i].when()
 		if w == state {
 			collectedSteps = append(collectedSteps, hit.steps[i])

--- a/hit_test.go
+++ b/hit_test.go
@@ -813,3 +813,9 @@ func TestJoinURL(t *testing.T) {
 		})
 	}
 }
+
+func TestNilStep(t *testing.T) {
+	s := EchoServer()
+	defer s.Close()
+	Test(t, nil, Get(s.URL), nil)
+}


### PR DESCRIPTION
## Description

## Problem
`go-hit` crashed when the provided step is nil.
Example:
```
Test(t,
	nil,
	Get(s.URL),
	nil,
)
```

## Solution
Filter out `nil` steps.

### Checklist
- [x] Ran `make test`
- [x] Review `README.md` `go //ignore` sections
- [x] Added Changelog entry to `README.md` when this is a `#major` or `#minor` release. 

<!--
Bumping
Any commit message that includes #major, #minor, or #patch will trigger the respective version bump.
If two or more are present, the highest-ranking one will take precedence.
If no #major, #minor or #patch tag is contained in the commit messages, it will bump patch.
-->