### PR TITLE
fix: `JSON().Len()` and `JSON().JQ().Len()` on null objects

### DIFF
--- a/expect_body_json.go
+++ b/expect_body_json.go
@@ -131,6 +131,9 @@ func (v *expectBodyJSON) Len() IExpectInt {
 	return newExpectInt(v.cleanPath.Push("Len", nil), func(hit Hit) int {
 		var obj interface{}
 		hit.Response().body.JSON().MustDecode(&obj)
+		if obj == nil {
+			return 0
+		}
 		rv := reflect.ValueOf(obj)
 		switch rv.Kind() {
 		case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice, reflect.String:

--- a/expect_body_json_jq.go
+++ b/expect_body_json_jq.go
@@ -146,6 +146,9 @@ func (v *expectBodyJSONJQ) Len() IExpectInt {
 	return newExpectInt(v.cleanPath.Push("Len", nil), func(hit Hit) int {
 		var obj interface{}
 		hit.Response().body.JSON().MustJQ(&obj, v.expression...)
+		if obj == nil {
+			return 0
+		}
 		rv := reflect.ValueOf(obj)
 		switch rv.Kind() {
 		case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice, reflect.String:

--- a/expect_body_json_jq_test.go
+++ b/expect_body_json_jq_test.go
@@ -322,6 +322,12 @@ func TestExpectBodyJSONJQ_Len(t *testing.T) {
 		Expect().Body().JSON().JQ(".Name").Len().Equal(3),
 	)
 
+	Test(t,
+		Post(s.URL),
+		Send().Body().String(`{"Name":"Joe", "ID": 10}`),
+		Expect().Body().JSON().JQ(".Group").Len().Equal(0),
+	)
+
 	ExpectError(t,
 		Do(
 			Post(s.URL),

--- a/expect_body_json_test.go
+++ b/expect_body_json_test.go
@@ -726,6 +726,12 @@ func TestExpectBodyJSON_Len(t *testing.T) {
 		Expect().Body().JSON().Len().Equal(2),
 	)
 
+	Test(t,
+		Post(s.URL),
+		Send().Body().String(`null`),
+		Expect().Body().JSON().Len().Equal(0),
+	)
+
 	ExpectError(t,
 		Do(
 			Post(s.URL),


### PR DESCRIPTION

## Problem
* `Expect().Body().JSON().Len()` is returning an error when the payload is null.
* `Expect().Body().JSON().JQ().Len()` is returning an error when the specified JQ expression returns null.

## Solution
Both cases should return a len of 0.

### Checklist
- [x] Ran `make test`
- [x] Review `README.md` `go //ignore` sections
- [x] Added Changelog entry to `README.md` when this is a `#major` or `#minor` release. 

<!--
Bumping
Any commit message that includes #major, #minor, or #patch will trigger the respective version bump.
If two or more are present, the highest-ranking one will take precedence.
If no #major, #minor or #patch tag is contained in the commit messages, it will bump patch.
-->