### PR TITLE
fix: Update update-github-tag-action (#50) #patch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: '0'
       -
         name: Bump version and push tag
-        uses: anothrNick/github-tag-action@1.26.0
+        uses: anothrNick/github-tag-action@1.35.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true


### PR DESCRIPTION
## Description

Build was failing on master branch since the `DEFAULT_BUMP` was set to `none`.
This new version should fix it.

### Checklist
- [x] Ran `make test`
- [x] Review `README.md` `go //ignore` sections
- [x] Added Changelog entry to `README.md` when this is a `#major` or `#minor` release. 

<!--
Bumping
Any commit message that includes #major, #minor, or #patch will trigger the respective version bump.
If two or more are present, the highest-ranking one will take precedence.
If no #major, #minor or #patch tag is contained in the commit messages, it will not bump.
-->