### PR TITLE
fix: `BaseURL` inconsistency (#51) #patch

### DIFF
--- a/hit_test.go
+++ b/hit_test.go
@@ -323,6 +323,25 @@ func TestBaseURL(t *testing.T) {
 	)
 }
 
+func TestBaseURLTemplate(t *testing.T) {
+	// this test should ensure that the baseurl is the same for the two test runs
+	mux := http.NewServeMux()
+	mux.HandleFunc("/foo/", func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusNoContent)
+	})
+	s := httptest.NewServer(mux)
+	defer s.Close()
+
+	steps := []IStep{
+		BaseURL("%s/foo", s.URL),
+		Get("/"),
+		Expect().Status().Equal(http.StatusNoContent),
+	}
+
+	Test(t, steps...)
+	Test(t, steps...)
+}
+
 func TestFormatURL(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/foo", func(writer http.ResponseWriter, request *http.Request) {

--- a/static.go
+++ b/static.go
@@ -158,7 +158,8 @@ func BaseURL(url string, a ...interface{}) IStep {
 		CallPath: newCallPath("BaseURL", nil),
 		Exec: func(hit *hitImpl) error {
 			if len(a) > 0 {
-				url = fmt.Sprintf(url, a...)
+				hit.baseURL = fmt.Sprintf(url, a...)
+				return nil
 			}
 			hit.baseURL = url
 			return nil
@@ -198,13 +199,13 @@ func makeMethodStep(fnName, method, url string, a ...interface{}) IStep {
 		CallPath: newCallPath(fnName, nil),
 		Exec: func(hit *hitImpl) error {
 			hit.request.Method = method
-			url = misc.MakeURL(hit.baseURL, url, a...)
-			if url == "" {
+			u := misc.MakeURL(hit.baseURL, url, a...)
+			if u == "" {
 				hit.request.URL = new(urlpkg.URL)
 				return nil
 			}
 			var err error
-			hit.request.URL, err = urlpkg.Parse(url)
+			hit.request.URL, err = urlpkg.Parse(u)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Description

## Problem
The `BaseURL` was modified when reusing the steps.

## Solution
Do not reuse stack variable.

### Checklist
- [x] Ran `make test`
- [x] Review `README.md` `go //ignore` sections
- [x] Added Changelog entry to `README.md` when this is a `#major` or `#minor` release. 

<!--
Bumping
Any commit message that includes #major, #minor, or #patch will trigger the respective version bump.
If two or more are present, the highest-ranking one will take precedence.
If no #major, #minor or #patch tag is contained in the commit messages, it will not bump.
-->