### PR TITLE
chore: install go before lint

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,7 +25,7 @@ jobs:
         name: Lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:
-          version: v2.5.2
+          version: v1.42.1
           # optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,7 +25,7 @@ jobs:
         name: Lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:
-          version: 2.52
+          version: v2.52
           # optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,9 +23,9 @@ jobs:
           go-version: ${{ steps.go-mod-details.outputs.go_version }}
       -
         name: Lint
-        uses: golangci/golangci-lint-action@v2.5.2
+        uses: golangci/golangci-lint-action@v3.2.0
         with:
-          version: v1.42.0
+          version: latest
           # optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,7 +25,7 @@ jobs:
         name: Lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:
-          version: v1.42.1
+          version: v1.42.0
           # optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,7 +25,7 @@ jobs:
         name: Lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:
-          version: v2.52
+          version: v2.5.2
           # optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,7 +25,7 @@ jobs:
         name: Lint
         uses: golangci/golangci-lint-action@v3.2.0
         with:
-          version: latest
+          version: v1.42.1
           # optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,9 +10,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
+        name: Checkout code
         uses: actions/checkout@v3.0.2
       -
-        name: lint
+        name: Get go.mod details
+        uses: Eun/go-mod-details@v1.0.4
+        id: go-mod-details
+      -
+        name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ steps.go-mod-details.outputs.go_version }}
+      -
+        name: Lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:
           version: latest

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,7 +25,7 @@ jobs:
         name: Lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:
-          version: latest
+          version: 2.52
           # optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true
 


### PR DESCRIPTION
## Description
Install the specified go version before running the linter

### Checklist
- [x] Ran `make test`
- [x] Review `README.md` `go //ignore` sections
- [x] Added Changelog entry to `README.md` when this is a `#major` or `#minor` release. 
