### PR TITLE
fix(CI): release drafter permissions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -87,6 +87,9 @@ jobs:
   # the configuration is at /.github/release-drafter.yml.
   update_release_draft:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
       - uses: release-drafter/release-drafter@v5
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
## Description

## Problem
Release Drafter now requires permissions to create a release.

## Solution
Add the permissions

## Notes
Other notes that you want to share but do not fit into _Problem_ or _Solution_.

### Checklist
- [ ] Ran `make test`
- [ ] Review `README.md` `go //ignore` sections
- [ ] Added Changelog entry to `README.md` when this is a `#major` or `#minor` release. 
